### PR TITLE
(Docker) (Fix) Make the whole `var/` directory a volume

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -32,7 +32,7 @@ EXPOSE 8080
 
 CMD ["./rabbit", "--config", "/app/configs/config.yml"]
 
-VOLUME /app/var/releases
+VOLUME /app/var/
 
 HEALTHCHECK --interval=5s --timeout=2s --retries=5 --start-period=2s \
   CMD ./rabbit --config /app/configs/config.yml --exec health

--- a/docker/docker-compose.example.yml
+++ b/docker/docker-compose.example.yml
@@ -13,8 +13,8 @@ services:
       depends_on:
          - redis
       volumes:
-         - ~/.ssh:/root/.ssh
-         - 'rabbit_releases:/app/var/releases'
+         - ~/.ssh:/root/.ssh/
+         - 'rabbit_releases:/app/var/'
       restart: unless-stopped
 
 volumes:


### PR DESCRIPTION
I've noticed, that I get the following error: "invalid cross-device link" when `os.Rename()` is called. So make the whole `var/` directory a volume.