### PR TITLE
Added support for Bitbucket Server

### DIFF
--- a/docker/config.docker.yml
+++ b/docker/config.docker.yml
@@ -86,3 +86,12 @@ integrations:
         https_format: https://bitbucket.org/{$full_name}.git
         # SSH URL format, Full name will be something like Clivern/Rabbit
         ssh_format: git@bitbucket.org:{$full_name}.git
+    bitbucket_server:
+        # Webhook URI (Full URL will be app.domain + webhook_uri)
+        webhook_uri: /webhook/bitbucket-server
+        # whether to use ssh or https to clone
+        clone_with: ${RABBIT_INTEGRATION_BITBUCKET_SERVER_CLONE_WITH:-https}
+        # HTTPS URL format, Full name will be something like Clivern/Rabbit
+        https_format: https://${RABBIT_INTEGRATION_BITBUCKET_SERVER_USER:-git}@${RABBIT_INTEGRATION_BITBUCKET_SERVER_HOSTNAME}/scm/{$project.key}/{$repository.slug}.git
+        # SSH URL format, Full name will be something like Clivern/Rabbit
+        ssh_format: ssh://${RABBIT_INTEGRATION_BITBUCKET_SERVER_USER:-git}@${RABBIT_INTEGRATION_BITBUCKET_SERVER_HOSTNAME}:${RABBIT_INTEGRATION_BITBUCKET_SERVER_SSH_PORT:-2200}/{$project.key}/{$repository.slug}.git

--- a/go.sum
+++ b/go.sum
@@ -10,6 +10,8 @@ github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghf
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/clivern/hippo v1.5.1 h1:O7AOJ3smbff9BqGA1Hypanu2aUEw7RHOEHgu1i6pMYM=
 github.com/clivern/hippo v1.5.1/go.mod h1:aGxjMpUlaGixQodYdrmKQMjpoItItFUjT/VILUETQG4=
+github.com/clivern/rabbit v0.0.0-20190619212833-cf34bb09610e h1:P3h9/hJYERiqY9Ly8sgt4cIBAmQ37yvkXWojEQBsvJ4=
+github.com/clivern/rabbit v0.0.0-20190619212833-cf34bb09610e/go.mod h1:ndBCWwd7/iTMzRd/PxPeM2D7njAP2yjj2vwRzk2muGo=
 github.com/coreos/bbolt v1.3.2/go.mod h1:iRUV2dpdMOn7Bo10OQBFzIJO9kkE559Wcmn+qkEiiKk=
 github.com/coreos/etcd v3.3.10+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=
 github.com/coreos/go-semver v0.2.0/go.mod h1:nnelYz7RCh+5ahJtPPxZlU+153eP4D4r3EedlOD2RNk=

--- a/internal/app/controller/bitbucket_server_listener.go
+++ b/internal/app/controller/bitbucket_server_listener.go
@@ -1,0 +1,102 @@
+package controller
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/clivern/hippo"
+	"github.com/clivern/rabbit/internal/app/model"
+	"github.com/clivern/rabbit/pkg"
+	"github.com/gin-gonic/gin"
+	"github.com/spf13/viper"
+	"go.uber.org/zap"
+)
+
+func BitbucketServerListener(c *gin.Context, messages chan<- string) {
+	rawBody, _ := c.GetRawData()
+	body := string(rawBody)
+
+	logger, _ := hippo.NewLogger(
+		viper.GetString("log.level"),
+		viper.GetString("log.format"),
+		[]string{viper.GetString("log.output")},
+	)
+
+	defer logger.Sync()
+
+	pushEvent := pkg.BitbucketServerPushEvent{}
+	ok, err := pushEvent.LoadFromJSON(rawBody)
+
+	if err != nil {
+		logger.Info(
+			fmt.Sprintf(
+				`Invalid event received %s, error: %s`,
+				body,
+				err,
+			),
+			zap.String("CorrelationID", c.Request.Header.Get("X-Correlation-ID")),
+		)
+
+		c.JSON(http.StatusForbidden, gin.H{
+			"status": "Oops!",
+		})
+		return
+	}
+
+	if !ok {
+		c.JSON(http.StatusForbidden, gin.H{
+			"status": "Oops!",
+		})
+		return
+	}
+
+	if len(pushEvent.Changes) <= 0 {
+		c.JSON(http.StatusOK, gin.H{
+			"status": "Nice, Skip!",
+		})
+		return
+	}
+
+	var cloneFormat string
+	var href string
+
+	// Push event received
+	if viper.GetString("integrations.bitbucket_server.clone_with") == "ssh" {
+		cloneFormat = viper.GetString("integrations.bitbucket_server.ssh_format")
+	} else {
+		cloneFormat = viper.GetString("integrations.bitbucket_server.https_format")
+	}
+
+	href = strings.ReplaceAll(
+		cloneFormat,
+		"{$project.key}",
+		strings.ToLower(pushEvent.Repository.Project.Key),
+	)
+
+	href = strings.ReplaceAll(
+		href,
+		"{$repository.slug}",
+		strings.ToLower(pushEvent.Repository.Slug),
+	)
+
+	logger.Info(fmt.Sprintf("Clone URL is: %s", href))
+
+	for _, changes := range pushEvent.Changes {
+		ref := changes.Ref
+		if ref.Type == pkg.BitbucketServerChangeTypeTag {
+			releaseRequest := model.ReleaseRequest{
+				Name:    pushEvent.Repository.Name,
+				URL:     href,
+				Version: ref.DisplayID,
+			}
+
+			passToWorker(
+				c,
+				messages,
+				logger,
+				releaseRequest,
+			)
+		}
+	}
+}

--- a/internal/app/controller/pass_to_worker.go
+++ b/internal/app/controller/pass_to_worker.go
@@ -1,13 +1,8 @@
-// Copyright 2019 Clivern. All rights reserved.
-// Use of this source code is governed by the MIT
-// license that can be found in the LICENSE file.
-
 package controller
 
 import (
 	"fmt"
 	"net/http"
-	"strings"
 
 	"github.com/clivern/hippo"
 	"github.com/clivern/rabbit/internal/app/model"
@@ -17,70 +12,7 @@ import (
 	"go.uber.org/zap"
 )
 
-// BitbucketListener controller
-func BitbucketListener(c *gin.Context, messages chan<- string) {
-
-	rawBody, _ := c.GetRawData()
-	body := string(rawBody)
-
-	logger, _ := hippo.NewLogger(
-		viper.GetString("log.level"),
-		viper.GetString("log.format"),
-		[]string{viper.GetString("log.output")},
-	)
-
-	defer logger.Sync()
-
-	pushEvent := pkg.PushEvent{}
-	ok, err := pushEvent.LoadFromJSON(rawBody)
-
-	if err != nil {
-		logger.Info(fmt.Sprintf(
-			`Invalid event received %s`,
-			body,
-		), zap.String("CorrelationID", c.Request.Header.Get("X-Correlation-ID")))
-
-		c.JSON(http.StatusForbidden, gin.H{
-			"status": "Oops!",
-		})
-		return
-	}
-
-	if !ok {
-		c.JSON(http.StatusForbidden, gin.H{
-			"status": "Oops!",
-		})
-		return
-	}
-
-	if len(pushEvent.Push.Changes) <= 0 || !pushEvent.Push.Changes[0].Created || pushEvent.Push.Changes[0].New.Type != "tag" {
-		c.JSON(http.StatusOK, gin.H{
-			"status": "Nice, Skip!",
-		})
-		return
-	}
-
-	// Push event received
-	href := strings.ReplaceAll(
-		viper.GetString("integrations.bitbucket.https_format"),
-		"{$full_name}",
-		pushEvent.Repository.FullName,
-	)
-
-	if viper.GetString("integrations.bitbucket.clone_with") == "ssh" {
-		href = strings.ReplaceAll(
-			viper.GetString("integrations.bitbucket.ssh_format"),
-			"{$full_name}",
-			pushEvent.Repository.FullName,
-		)
-	}
-
-	releaseRequest := model.ReleaseRequest{
-		Name:    pushEvent.Repository.Name,
-		URL:     href,
-		Version: pushEvent.Push.Changes[0].New.Name,
-	}
-
+func passToWorker(c *gin.Context, messages chan<- string, logger *zap.Logger, releaseRequest model.ReleaseRequest) {
 	validate := pkg.Validator{}
 
 	if validate.IsEmpty(releaseRequest.Name) {
@@ -130,7 +62,7 @@ func BitbucketListener(c *gin.Context, messages chan<- string) {
 		)
 
 		// connect to redis server
-		ok, err = driver.Connect()
+		ok, err := driver.Connect()
 
 		if err != nil {
 			logger.Error(fmt.Sprintf(

--- a/pkg/bitbucket_server_events.go
+++ b/pkg/bitbucket_server_events.go
@@ -1,0 +1,88 @@
+package pkg
+
+import (
+	"encoding/json"
+	"strings"
+	"time"
+)
+
+const (
+	bitbucketDateFormat          string = "2006-01-02T15:04:05+0000"
+	BitbucketServerChangeTypeTag        = "TAG"
+)
+
+type BitbucketServerPushEvent struct {
+	EventKey   string              `json:"eventKey"`
+	Date       bitbucketServerDate `json:"date"`
+	Actor      bitbucketUser       `json:"actor"`
+	Repository struct {
+		Slug         string `json:"slug"`
+		ID           int    `json:"id"`
+		Name         string `json:"name"`
+		SCMID        string `json:"scmId"`
+		State        string `json:"state"`
+		StateMessage string `json:"statusMessage"`
+		Forkable     bool   `json:"forkable"`
+		Project      struct {
+			Key   string        `json:"key"`
+			ID    int           `json:"id"`
+			Name  string        `json:"name"`
+			Type  string        `json:"type"`
+			Owner bitbucketUser `json:"owner"`
+		} `json:"project"`
+		Public bool `json:"public"`
+	} `json:"repository"`
+	Changes []struct {
+		Ref struct {
+			ID        string `json:"id"`
+			DisplayID string `json:"displayId"`
+			Type      string `json:"type"`
+		} `json:"ref"`
+		RefID    string `json:"refId"`
+		FromHash string `json:"fromHash"`
+		ToHash   string `json:"toHash"`
+		Type     string `json:"type"`
+	} `json:"changes"`
+}
+
+type bitbucketUser struct {
+	Name         string `json:"name"`
+	EmailAddress string `json:"emailAddress"`
+	ID           int    `json:"id"`
+	DisplayName  string `json:"displayName"`
+	Active       bool   `json:"active"`
+	Slug         string `json:"slug"`
+	Type         string `json:"type"`
+}
+
+type bitbucketServerDate struct {
+	time.Time
+}
+
+func (bt *bitbucketServerDate) UnmarshalJSON(b []byte) (err error) {
+	s := strings.Trim(string(b), "\"")
+	if s == "null" {
+		bt.Time = time.Now()
+		return
+	}
+	bt.Time, err = time.Parse(bitbucketDateFormat, s)
+	return
+}
+
+// LoadFromJSON update object from json
+func (e *BitbucketServerPushEvent) LoadFromJSON(data []byte) (bool, error) {
+	err := json.Unmarshal(data, &e)
+	if err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+// ConvertToJSON convert object to json
+func (e *BitbucketServerPushEvent) ConvertToJSON() (string, error) {
+	data, err := json.Marshal(&e)
+	if err != nil {
+		return "", err
+	}
+	return string(data), nil
+}

--- a/rabbit.go
+++ b/rabbit.go
@@ -121,11 +121,17 @@ func main() {
 
 	r.GET("/api/project/:id", controller.GetProjectByID)
 	r.GET("/api/project", controller.GetProjects)
+
 	r.POST(strings.TrimSuffix(viper.GetString("integrations.github.webhook_uri"), "/"), func(c *gin.Context) {
 		controller.GithubListener(c, messages)
 	})
+
 	r.POST(strings.TrimSuffix(viper.GetString("integrations.bitbucket.webhook_uri"), "/"), func(c *gin.Context) {
 		controller.BitbucketListener(c, messages)
+	})
+
+	r.POST(strings.TrimSuffix(viper.GetString("integrations.bitbucket_server.webhook_uri"), "/"), func(c *gin.Context) {
+		controller.BitbucketServerListener(c, messages)
 	})
 
 	for i := 0; i < viper.GetInt("broker.native.workers"); i++ {


### PR DESCRIPTION
Added another webhook that allows Bitbucket Server to push updates to Rabbit. Tested with Bitbucket Server v5.9.1.

- Pushing multiple tags at once is supported

Sample data coming from Bitbucket Server

```json
{
  "eventKey": "repo:refs_changed",
  "date": "2019-06-20T11:36:42+0000",
  "actor": {
      "name": "User",
      "emailAddress": "user@example.com",
      "id": 51,
      "displayName": "Firstname Lastname",
      "active": true,
      "slug": "user",
      "type": "NORMAL"
  },
  "repository": {
    "slug": "test-rabbit",
    "id": 872,
    "name": "test-rabbit",
    "scmId": "git",
    "state": "AVAILABLE",
    "statusMessage": "Available",
    "forkable": true,
    "project": {
      "key": "~USER",
      "id": 1,
      "name": "Firstname Lastname",
      "type": "PERSONAL",
      "owner": {
        "name": "User",
        "emailAddress": "user@example.com",
        "id": 51,
        "displayName": "Firstname Lastname",
        "active": true,
        "slug": "user",
        "type": "NORMAL"
      }
    },
    "public": false
  },
  "changes": [
    {
      "ref": {
        "id": "refs/heads/master",
        "displayId": "master",
        "type": "BRANCH"
      },
      "refId": "refs/heads/master",
      "fromHash": "d2cc1a8172b575f991a0926d1c5d9bd7dab9f508",
      "toHash": "398a5c3837db7b57807a781f648861408fe4b990",
      "type": "UPDATE"
    },
    {
      "ref": {
        "id": "refs/tags/v1.1.3",
        "displayId": "v1.1.3",
        "type": "TAG"
      },
      "refId": "refs/tags/v1.1.3",
      "fromHash": "0000000000000000000000000000000000000000",
      "toHash": "d8b3dc320995afa77a32ceacb32636c2c1b83743",
      "type": "ADD"
    }
  ]
}

```